### PR TITLE
Improve record processing and  error fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ exports.handler = (event, context, callback) => {
   if (record.kinesis && record.kinesis.data) {
     exports.kinesisHandler(
       event.Records,
-      { schema: '', apiUri: process.env.NYPL_DATA_API_URL },
+      { schema: 'HoldRequestService', apiUri: process.env.NYPL_DATA_API_URL },
       context
     );
   }

--- a/index.js
+++ b/index.js
@@ -29,9 +29,6 @@ exports.kinesisHandler = (records, opts = {}, context) => {
       });
     }
 
-    // Required parameters are valid execute the following:
-    // 1) Obtain the decoded kinesis data
-    // 2) Obtain a valid OAuth token to process record data
     const schema = opts.schema;
     const apiUri = opts.apiUri;
     const streamsClient = new NyplStreamsClient({ nyplDataApiClientBase: apiUri });
@@ -41,29 +38,45 @@ exports.kinesisHandler = (records, opts = {}, context) => {
       process.env.OAUTH_CLIENT_SECRET,
       process.env.OAUTH_PROVIDER_SCOPE
     );
-    const holdRequestConsumerModel = new HoldRequestConsumerModel();
+    const hrcModel = new HoldRequestConsumerModel();
 
     Promise.all([
       apiHelper.getOAuthToken(CACHE['access_token']),
       streamsClient.decodeData(schema, records.map(i => i.kinesis.data))
     ]).then(result => {
-      // The access_token has been obtained and all records have been grouped by source
-      // Next, we need create a string from the record and nyplSource keys to perform a GET request
-      // to the ItemService
       CACHE['access_token'] = result[0];
       // Save the decoded records to the Model Object
-      holdRequestConsumerModel.setRecords(result[1]);
-
-      const groupedRecordsBySource = apiHelper.groupRecordsBy(holdRequestConsumerModel.getRecords(), 'nyplSource');
-      const groupedRecordsWithApiUrl = apiHelper.generateRecordApiUrlsArray(groupedRecordsBySource, apiUri);
-      console.log(groupedRecordsWithApiUrl);
+      hrcModel.setRecords(result[1]);
+      return apiHelper.generateRecordApiUrlsArray(hrcModel.getRecords(), apiUri);
+    })
+    .then(apiUrlsArray => {
+      hrcModel.setApiUrlsArray(apiUrlsArray);
+      return apiHelper.processBatchRequest(hrcModel.getApiUrlsArray(), CACHE['access_token'], 'itemApi');
+    })
+    .then(recordsWithItemData => {
+      return hrcModel.mergeRecordsBySourceAndRecordId(hrcModel.getRecords(), recordsWithItemData);
+    })
+    .then(updatedRecordsWithItemData => {
+      hrcModel.setRecords(updatedRecordsWithItemData);
+      console.log(hrcModel.getRecords()[0]);
+      // return apiHelper.processBatchRequest(hrcModel.getApiUrlsArray(), CACHE['access_token'], 'patronBarcodeApi');
+    })
+    .then(recordsWithPatronBarcode => {
+      // console.log(recordsWithPatronBarcode);
     })
     .catch(error => {
-      console.log('Error from Promise All', error);
-    });
+      console.log('PROMISE CHAIN CATCH:', error);
+      // Handling Errors From Promise Chain
+      if (error.status === 403) {
+        // Handle Forbidden Errors
+      }
 
+      if (error.status === 401) {
+        // Handle OAuth Token refresh
+      }
+    });
   } catch (error) {
-    console.log(error);
+    console.log('CATCH ALL BLOCK:', error);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@nypl/nypl-streams-client": "0.1.4",
     "async": "2.5.0",
     "axios": "0.16.2",
-    "lodash": "4.17.4",
     "qs": "6.4.0",
     "winston": "2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   "homepage": "https://github.com/NYPL/nypl-hold-request-consumer#readme",
   "dependencies": {
     "@nypl/nypl-streams-client": "0.1.4",
+    "async": "^2.5.0",
     "axios": "0.16.2",
+    "lodash": "^4.17.4",
     "qs": "6.4.0"
   },
   "devDependencies": {

--- a/sample/sample_event.json
+++ b/sample/sample_event.json
@@ -1,132 +1,132 @@
 {
   "Records": [
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "kgFIMDYwZWZiYjAtOTQ3My00ZjlhLWFiYTQtYmFhMmYzYmM0MmNmEDY3NzkzNjY2FnNpZXJyYS1ueXBsADIyMDE3LTA2LTIyVDExOjA3OjM3LTA0OjAwAgAACGhvbGQCaRAxMzE1MzMyNwAIc2FzYgAyMjAxNi0wMS0wN1QwMjozMjo1MSswMDowMAACAgICAgICAgI=",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "ggJIMzA0N2JhOGYtMTAxNi00NmZhLTllODYtOGYxMDM5NDQ3ZDEwDjY3NzkzNjYWc2llcnJhLW55cGwCMjIwMTctMDYtMjhUMDg6MDM6NTUtMDQ6MDAAAAAIaG9sZAJpEDEzMTUzMzI3AghzYXNiAjIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAgIAAgAAAAAAAA==",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "kAFIYTdmY2Y5N2MtZjBiNi00OGY0LWJjMjYtNGRlNTE5MGFlMzYxEDY3NzkzNjY2FnNpZXJyYS1ueXBsADIyMDE3LTA2LTIyVDExOjA3OjExLTA0OjAwAgAACGhvbGQCaRAxMTA2NDI4OAAIc2FzYgAyMjAxNi0wMS0wN1QwMjozMjo1MSswMDowMAACAgICAgICAgI=",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "hAJIMzljNDcwODgtMTRhNC00M2JmLTk5YzMtMDM3YjJjMGYyMTk0DjY3NzkzNjYWc2llcnJhLW55cGwCMjIwMTctMDYtMjhUMDg6MDQ6NTgtMDQ6MDAAAAAIaG9sZAJpEDExMDY0Mjg4AghzYXNiAjIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAgIAAgAAAAAAAA==",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "jgFIYjY3ZDg2MmItMmIzMi00NDVhLWJjODMtZGQ1MjVjZTMwYWU5EDY3NzkzNjY2FnNpZXJyYS1ueXBsADIyMDE3LTA2LTIyVDExOjA2OjQwLTA0OjAwAgAACGhvbGQCaRAxMDAxMDY2MgAIc2FzYgAyMjAxNi0wMS0wN1QwMjozMjo1MSswMDowMAACAgICAgICAgI=",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "hgJIMzM5ZDA4Y2EtZjE3Zi00OWFlLTlkNTctYjc0OTBkNTlhOTFjDjY3NzkzNjYWc2llcnJhLW55cGwCMjIwMTctMDYtMjhUMDg6MDY6MTQtMDQ6MDAAAAAIaG9sZAJpEDEwMDEwNjYyAghzYXNiAjIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAgIAAgAAAAAAAA==",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "jAFIZGYyOTM0OTAtM2Y2Mi00NzU3LThjNzctMmQ2M2ZiMjA4MTYzEDY3NzkzNjY2FnNpZXJyYS1ueXBsADIyMDE3LTA2LTIyVDExOjA2OjA5LTA0OjAwAgAACGhvbGQCaRAxMDAxMTA4NQAIc2FzYgAyMjAxNi0wMS0wN1QwMjozMjo1MSswMDowMAACAgICAgICAgI=",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "iAJINDQyMjA5MGItZWE3Ni00YjI4LTlmZDYtY2RlN2MzNTYwNmY0DjY3NzkzNjYWc2llcnJhLW55cGwCMjIwMTctMDYtMjhUMDg6MDc6MDItMDQ6MDAAAAAIaG9sZAJpEDEwMDExMDg1AghzYXNiAjIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAgIAAgAAAAAAAA==",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "igFIZWI0ODE3YzgtMzRhNy00MjBjLTk3ZTgtOTY2MTIxMmRhY2ZhEDY3NzkzNjY2EnJlY2FwLXB1bAAyMjAxNy0wNi0yMlQxMTowNTozMy0wNDowMAIAAAhob2xkAmkMMTAwMDUyAAhzYXNiADIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAAICAgICAgICAg==",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "igJIOTU0ZmNiOWMtNzg4ZS00NzQ5LWE4YzAtZjU2YzVlODk0ZjVkDjY3NzkzNjYScmVjYXAtcHVsAjIyMDE3LTA2LTI4VDA4OjA4OjAxLTA0OjAwAAAACGhvbGQCaQwxMDAwNTICCHNhc2ICMjIwMTYtMDEtMDdUMDI6MzI6NTErMDA6MDACAgACAAAAAAAA",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "iAFIY2YyMjk3MmUtZmI4Zi00MjM3LTk3OTQtZGU4ZGRhMTY4MzZiEDY3NzkzNjY2EnJlY2FwLXB1bAAyMjAxNy0wNi0yMlQxMTowNTowMi0wNDowMAIAAAhob2xkAmkMMTAwMDI3AAhzYXNiADIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAAICAgICAgICAg==",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "jAJIOWUwYjk4YWUtMDYxYi00MmQ1LWEwMDAtM2JiOTk4NWEwNDVkDjY3NzkzNjYScmVjYXAtcHVsAjIyMDE3LTA2LTI4VDA4OjA4OjM1LTA0OjAwAAAACGhvbGQCaQwxMDAwMjcCCHNhc2ICMjIwMTYtMDEtMDdUMDI6MzI6NTErMDA6MDACAgACAAAAAAAA",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "hgFIM2NhMjEyNjctNDBkZC00YzQ1LTgxNWUtZGVhY2Y1NTRkNDUxEDY3NzkzNjY2EnJlY2FwLWN1bAAyMjAxNy0wNi0yMlQxMTowNDoyNC0wNDowMAIAAAhob2xkAmkMMzAyNjk2AAhzYXNiADIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAAICAgICAgICAg==",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "jgJIMDdkMjBlYjgtMjE5NC00YThlLTk0YTUtNmFlMDc2ODQwNTVkDjY3NzkzNjYScmVjYXAtY3VsAjIyMDE3LTA2LTI4VDA4OjA5OjE2LTA0OjAwAAAACGhvbGQCaQwzMDI2OTYCCHNhc2ICMjIwMTYtMDEtMDdUMDI6MzI6NTErMDA6MDACAgACAAAAAAAA",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     },
     {
-      "kinesis": {
-        "kinesisSchemaVersion": "1.0",
-        "partitionKey": "s1",
-        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
-        "data": "hAFINjA1YTQ3YmItZjQ4NS00Y2U3LWEyODUtYWQxMzdmZGZiNWRlEDY3NzkzNjY2EnJlY2FwLWN1bAAyMjAxNy0wNi0yMlQxMTowMzo0My0wNDowMAIAAAhob2xkAmkMMzAwMTM1AAhzYXNiADIyMDE2LTAxLTA3VDAyOjMyOjUxKzAwOjAwAAICAgICAgICAg==",
-        "approximateArrivalTimestamp": 1428537600
-      },
-      "eventSource": "aws:kinesis",
-      "eventVersion": "1.0",
+      "awsRegion": "us-east-1",
       "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
       "eventName": "aws:kinesis:record",
+      "eventSource": "aws:kinesis",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "eventVersion": "1.0",
       "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
-      "awsRegion": "us-east-1",
-      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+      "kinesis": {
+        "approximateArrivalTimestamp": 1428537600,
+        "data": "kAJIMGIyODVhODgtZDViMi00Yjc5LTg3ZTQtZTU3NmVkNmIyMWQyDjY3NzkzNjYScmVjYXAtY3VsAjIyMDE3LTA2LTI4VDA4OjEwOjA1LTA0OjAwAAAACGhvbGQCaQwzMDAxMzUCCHNhc2ICMjIwMTYtMDEtMDdUMDI6MzI6NTErMDA6MDACAgACAAAAAAAA",
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001"
+      }
     }
   ]
 }

--- a/src/globals/index.js
+++ b/src/globals/index.js
@@ -1,0 +1,23 @@
+const CACHE = module.exports = {
+  access_token: null,
+  nypl_data_api_base: '',
+  schema_name: '',
+  getAccessToken: function() {
+    return CACHE.access_token;
+  },
+  setAccessToken: function(token) {
+    CACHE.access_token = token;
+  },
+  getNyplDataApiBase: function() {
+    return CACHE.nypl_data_api_base;
+  },
+  setNyplDataApiBase: function(url) {
+    CACHE.nypl_data_api_base = url;
+  },
+  getSchemaName: function() {
+    return CACHE.schema_name;
+  },
+  setSchemaName: function(name) {
+    CACHE.schema_name = name;
+  }
+};

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -78,7 +78,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
             // TODO: POST FAILURE TO STREAM
             logger.error(
               'unable to retrieve item data for hold request record, posting failed record to HoldRequestResult stream',
-              { holdRequestId: item.id, record: item, error: hrcError }
+              { holdRequestId: item.id, record: item }
             );
 
             // Ignore all other failures and continue with callback, except 401 (access_token expired)
@@ -138,7 +138,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
             // TODO: POST FAILURE TO STREAM
             logger.error(
               'unable to retrieve patron data for hold request record, posting failed record to HoldRequestResult stream',
-              { holdRequestId: item.id, record: item, error: hrcError }
+              { holdRequestId: item.id, record: item }
             );
 
             // Ignore all other failures and continue with callback, except 401 (access_token expired)

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -3,6 +3,8 @@ const async = require('async');
 const axios = require('axios');
 const qs = require('qs');
 const HoldRequestConsumerError = require('../models/HoldRequestConsumerError');
+const logger = require('../helpers/Logger');
+const CACHE = require('../globals/index');
 
 function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '', grantType = 'client_credentials') {
   if (!(this instanceof ApiServiceHelper)) {
@@ -30,196 +32,152 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
       this.clientSecret === '' || this.scope === '') ? false : true;
   };
 
-  this.processGetItemDataRequests = (itemsArray, token) => {
-    const functionName = 'processGetItemDataRequests';
-
-    return new Promise((resolve, reject) => {
-      async.map(itemsArray, (urlItem, cb) => {
-        return axios.get(urlItem.itemApi, this.constructApiHeaders(token))
-        .then(response => {
-          if (response.data && response.data.data) {
-            cb(null, response.data.data);
-          }
-        })
-        .catch((error) => cb(error));
-      }, (err, results) => {
-        if (err) {
-          let errorResponse = {
-            type: 'item-service-api',
-            function: functionName
-          };
-
-          if (err.response) {
-            // The request was made and the server responded with a status code
-            // that falls out of the range of 2xx
-            errorResponse = HoldRequestConsumerError(Object.assign({}, errorResponse, {
-              message: 'received a status outside of the 2xx range from Item Service',
-              status: err.response.status,
-              error : {
-                method: err.response.request.method,
-                url: err.response.request.path,
-                headers: err.response.headers,
-                data: err.response.data
-              }
-            }));
-          } else if (err.request) {
-            // The request was made but no response was received
-            errorResponse = HoldRequestConsumerError(Object.assign({}, errorResponse, {
-              message: 'request was made, no response from Item Service',
-              status: 500,
-              error : err.request
-            }));
-          } else {
-            errorResponse = HoldRequestConsumerError(Object.assign({}, errorResponse, {
-              message: err.message || 'an error occured from Item Service',
-              status: 500,
-              error: err,
-            }));
-          }
-          // Reject the promise with the proper HRC Error
-          reject(errorResponse);
-        } else {
-          // Merge two-dimensional array
-          const mergedArrayResults = [].concat.apply([], results);
-          resolve(mergedArrayResults);
-        }
-      });
-    });
+  this.handleErrors = (errorResponse) => {
+    console.log(errorResponse);
   };
 
-  this.processGetPatronBarcodeRequests = (itemsArray, token, baseApiUrl) => {
-    const functionName = 'processGetPatronBarcodeRequests';
-    // Only require the baseApiUrl to concatenate the patronBarcodeApi
-    if (!baseApiUrl || baseApiUrl === '') {
+
+  this.processGetItemDataRequests = (records, token) => {
+    const functionName = 'processGetItemDataRequests';
+    const nyplDataApiBase = CACHE.getNyplDataApiBase();
+
+    if (!nyplDataApiBase || nyplDataApiBase === '') {
+      logger.error('unable to process GET requests to Item Service for records; missing NYPL Data API base url');
       return Promise.reject(
         HoldRequestConsumerError({
-          message: `the baseApiUrl parameter is not defined or empty for type: ${type}`,
-          type: 'undefined-base-api-url-parameter',
+          message: 'the NYPL Data API base url not defined in CACHE',
+          type: 'undefined-nypl-data-api-base-url',
           function: functionName
         })
       );
     }
 
+    logger.info(`starting async iteration over ${records.length} records to fetch item data for each record`);
     return new Promise((resolve, reject) => {
-      itemsArray[0].patron = 'testfakepatron';
-
-      async.map(itemsArray, (item, callback) => {
-        // Only process GET requests if the patron value is defined
-        if (item.patron && item.patron !== '') {
-          const patronBarcodeApi = `${baseApiUrl}patrons/${item.patron}/barcode`;
-          return axios.get(patronBarcodeApi, this.constructApiHeaders(token))
+      async.map(records, (item, callback) => {
+        // Only process GET requests if the record and nyplSource values are defined
+        if (item.record && item.record !== ''
+          && item.nyplSource && item.nyplSource !== '') {
+          const itemApi = `${nyplDataApiBase}items/${item.nyplSource}/${item.record}`;
+          logger.info('fetching item data for hold request record', { holdRequestId: item.id });
+          return axios.get(itemApi, this.constructApiHeaders(token))
           .then(response => {
-            if (response.data && response.data.data) {
-              item['patronInfo'] = response.data.data;
-              // console.log(response.data.data);
-              callback(null, item);
-              // resolve(item);
-            }
-            // else {
-            //   callback({
-            //     holdRequestId: item.id,
-            //     status: 404,
-            //     type: 'missing-response-data',
-            //     message: 'unable to assign the patronInfo key to record. Did not obtain a response.data.data value.'
-            //   });
-            // }
+            logger.info('successfully fetched item data, assigned response to hold request record', { holdRequestId: item.id });
+            item['item'] = response.data.data;
+            return callback(null, item);
           })
           .catch((error) => {
-            // TODO: LOG ERROR & SEND TO STREAM ERROR ITEM
-            console.log('ERROR FOR holdRequestId: ' + item.id);
-            callback(null);
-            //callback(Object.assign({}, error, { holdRequestId: item.id }));
+            const hrcError = HoldRequestConsumerError({
+              message: `an error was received from Item Service for HoldRequestId: ${item.id}`,
+              type: 'item-service-error',
+              status: error.response && error.response.status ? error.response.status : 400,
+              function: functionName,
+              error : error.response || null
+            });
+
+            // TODO: POST FAILURE TO STREAM
+            logger.error(
+              'unable to retrieve item data for hold request record, posting failed record to HoldRequestResult stream',
+              { holdRequestId: item.id, record: item, error: hrcError }
+            );
+
+            // Ignore all other failures and continue with callback, except 401 (access_token expired)
+            return (error.response && error.response.status === 401) ? callback(hrcError) : callback(null);
           });
-        } else {
-
-          // TODO: LOG MISSING PATRON VALUE POST TO STREAM
-          // callback(
-          //   HoldRequestConsumerError({
-          //     message: 'could not generate a patron barcode API url; undefined or empty patron value',
-          //     type: 'missing-patron-key-value',
-          //     status: 404,
-          //     holdRequestId: item.id,
-          //     error : {
-          //       data: item,
-          //     }
-          //   })
-          // );
         }
+
+        // TODO: POST FAILURE TO STREAM
+        logger.error(
+          'unable to perform GET request to Item Service for hold request record; empty/undefined nyplSource and record key values',
+          { holdRequestId: item.id, record: item }
+        );
+        return callback(null);
       }, (err, results) => {
-        // console.log(results);
-        // console.log(results.length);
-
-        if (!err) {
-          resolve(results.filter(n => n));
-        }
-        // if (results) {
-        //   const filteredArray = resluts.filter(n => n );
-        //   console.log(filteredArray);
-        // }
-        // Handle the appropriate error for each result
-        // if (err) {
-        //   let errorResponse = Object.assign({}, {
-        //     type: 'patron-service-api',
-        //     function: functionName,
-        //   }, err);
-        //
-        //   if (err.response) {
-        //     // The request was made and the server responded with a status code
-        //     // that falls out of the range of 2xx
-        //     errorResponse = HoldRequestConsumerError(Object.assign({}, errorResponse, {
-        //       message: 'received a status outside of the 2xx range from Patron Service',
-        //       status: err.response.status,
-        //       error : {
-        //         method: err.response.request.method,
-        //         url: err.response.request.path,
-        //         headers: err.response.headers,
-        //         data: err.response.data
-        //       }
-        //     }));
-        //   } else if (err.request) {
-        //     // The request was made but no response was received
-        //     errorResponse = HoldRequestConsumerError(Object.assign({}, errorResponse, {
-        //       message: 'request was made, no response from Patron Service',
-        //       status: 500,
-        //       error : err.request
-        //     }));
-        //   } else {
-        //     errorResponse = HoldRequestConsumerError(Object.assign({}, errorResponse, {
-        //       message: err.message,
-        //       status: err.status || 500,
-        //       error: err.error
-        //     }));
-        //   }
-        //   // Reject the promise with the proper HRC Error
-        //   // reject(errorResponse);
-        // }
-        //
-        // if (results){
-        //   const mergedArrayResults = [].concat.apply([], results);
-        //   console.log(results);
-        //   // resolve(mergedArrayResults);
-        // }
+        return (err) ? this.handleErrors(err) : resolve(results.filter(n => n));
       });
     });
   };
 
-  this.processBatchRequest = (itemsArray, token, type, baseApiUrl) => {
-    const functionName = 'processBatchRequest';
+  this.processGetPatronBarcodeRequests = (records, token) => {
+    const functionName = 'processGetPatronBarcodeRequests';
+    const nyplDataApiBase = CACHE.getNyplDataApiBase();
+
+    if (!nyplDataApiBase || nyplDataApiBase === '') {
+      logger.error('unable to process GET requests to Patron Service for records; missing NYPL Data API base url');
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the NYPL Data API base url not defined in CACHE',
+          type: 'undefined-nypl-data-api-base-url',
+          function: functionName
+        })
+      );
+    }
+
+    logger.info(`starting async iteration over ${records.length} records to fetch patron data for each record`);
+    return new Promise((resolve, reject) => {
+      async.map(records, (item, callback) => {
+        // Only process GET requests if the patron value is defined
+        if (item.patron && item.patron !== '') {
+          const patronBarcodeApi = `${nyplDataApiBase}patrons/${item.patron}/barcode`;
+          logger.info('fetching patron data for hold request record', { holdRequestId: item.id });
+          return axios.get(patronBarcodeApi, this.constructApiHeaders(token))
+          .then(response => {
+            logger.info('successfully fetched patron data, assigned response to hold request record', { holdRequestId: item.id });
+            item['patronInfo'] = response.data.data;
+            return callback(null, item);
+          })
+          .catch((error) => {
+            const hrcError = HoldRequestConsumerError({
+              message: `an error was received from Patron Service for HoldRequestId: ${item.id}`,
+              type: 'patron-service-error',
+              status: error.response && error.response.status ? error.response.status : 400,
+              function: functionName,
+              error : error.response || null
+            });
+
+            // TODO: POST FAILURE TO STREAM
+            logger.error(
+              'unable to retrieve patron data for hold request record, posting failed record to HoldRequestResult stream',
+              { holdRequestId: item.id, record: item, error: hrcError }
+            );
+
+            // Ignore all other failures and continue with callback, except 401 (access_token expired)
+            return (error.response && error.response.status === 401) ? callback(hrcError) : callback(null);
+          });
+        }
+
+        // TODO: POST FAILURE TO STREAM
+        logger.error(
+          'unable to perform GET request to Patron Service for hold request record; empty/undefined patron key value',
+          { holdRequestId: item.id, record: item }
+        );
+        return callback(null);
+      }, (err, results) => {
+        return (err) ? this.handleErrors(err) : resolve(results.filter(n => n));
+      });
+    });
+  };
+
+  this.handleHttpAsyncRequests = (records, type) => {
+    const functionName = 'handleHttpAsyncRequests';
+    // Retrieve CACHED access_token initialized at the beginning of the handler
+    const token = CACHE.getAccessToken();
+
     if (!token || token === '') {
       return Promise.reject(
         HoldRequestConsumerError({
-          message: 'the token parameter is not defined or empty',
-          type: 'undefined-token-parameter',
+          message: 'the OAuth access_token is not defined or empty, could not perform HTTP async requests',
+          type: 'undefined-access-token-from-cache',
           function: functionName
         })
       );
     }
 
-    if (!itemsArray.length) {
+    if (!records.length) {
       return Promise.reject(
         HoldRequestConsumerError({
-          message: 'the urls array parameter is empty',
-          type: 'empty-urls-array-parameter',
+          message: 'the hold requests records array is empty',
+          type: 'empty-records-array-parameter',
           function: functionName
         })
       );
@@ -235,154 +193,21 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
       );
     }
 
-    if (type === 'itemApi') {
-      return this.processGetItemDataRequests(itemsArray, token);
+    if (type === 'item-service') {
+      return this.processGetItemDataRequests(records, token);
     }
 
-    if (type === 'patronBarcodeApi') {
-      return this.processGetPatronBarcodeRequests(itemsArray, token, baseApiUrl);
+    if (type === 'patron-barcode-service') {
+      return this.processGetPatronBarcodeRequests(records, token);
+    }
+
+    if (type === 'recap-service') {
+      // return this.postRecordsToRecap(records);
     }
   };
 
-  this.generateItemApiUrlsArray = (records, baseApiUrl) => {
-    const functionName = 'generateItemApiUrlsArray';
-    if (!baseApiUrl || baseApiUrl === '') {
-      return Promise.reject(
-        HoldRequestConsumerError({
-          message: 'the baseApiUrl parameter is not defined or empty',
-          type: 'undefined-base-api-url-parameter',
-          function: functionName
-        })
-      );
-    }
-
-    if (!records) {
-      return Promise.reject(
-        HoldRequestConsumerError({
-          message: 'the records array parameter is not defined',
-          type: 'undefined-records-array-parameter',
-          function: functionName
-        })
-      );
-    }
-
-    if (!records.length) {
-      return Promise.reject(
-        HoldRequestConsumerError({
-          message: 'the records array parameter is empty',
-          type: 'empty-records-array-parameter',
-          function: functionName
-        })
-      );
-    }
-
-    const groupedRecords = this.groupRecordsBy(records, 'nyplSource');
-
-    if (Object.keys(groupedRecords).length === 0) {
-      return Promise.reject(
-        HoldRequestConsumerError({
-          message: 'the groupedRecords object is empty, could not iterate over object keys',
-          type: 'empty-grouped-records-object',
-          function: functionName
-        })
-      );
-    }
-
-    // Create the Items API URL from the base URL
-    const itemApiUrlBase = `${baseApiUrl}items?id=`;
-    const itemApiUrlsArray = [];
-    // Store a reference that will be re-assigned and concatenated
-    let itemApiUrl = itemApiUrlBase;
-    // Iterate over the records object keys grouped by nyplSource
-    Object.keys(groupedRecords).forEach((key) => {
-      const arrayOfDecodedRecords = groupedRecords[key];
-
-      if (typeof arrayOfDecodedRecords !== 'object' || !arrayOfDecodedRecords.length) {
-        return Promise.reject(
-            HoldRequestConsumerError({
-            message: 'the decoded data array is empty',
-            type: 'empty-decoded-data-array',
-            function: functionName,
-            error: { nyplSource: key, data: arrayOfDecodedRecords }
-          })
-        );
-      }
-
-      // Iterate over each record data to extract the record id
-      Object.keys(arrayOfDecodedRecords).forEach((k) => {
-        // Verify the existence of the 'record' property
-        if (!arrayOfDecodedRecords[k].hasOwnProperty('record') || !arrayOfDecodedRecords[k].record) {
-          return Promise.reject(
-            HoldRequestConsumerError({
-              message: 'the record object key within the item id is not defined',
-              type: 'empty-object-property-record',
-              function: functionName,
-              error: { nyplSource: key, data: arrayOfDecodedRecords[k] }
-            })
-          );
-        }
-
-        // Append the record value (id) to url string
-        itemApiUrl += arrayOfDecodedRecords[k].record;
-
-        // Append a comma (,) to all except the last item
-        if (arrayOfDecodedRecords.length !== (parseInt(k) + 1)) {
-          itemApiUrl += ',';
-        }
-      });
-      // Append the nyplSource to the end of the string
-      itemApiUrl += '&nyplSource=' + key;
-      // Add the Item API Url and data to final array
-      itemApiUrlsArray.push({
-        'nyplSource': key,
-        'itemApi': itemApiUrl,
-        'data': arrayOfDecodedRecords
-      });
-      // Reset the item URL for the next record
-      itemApiUrl = itemApiUrlBase;
-    });
-
-    return Promise.resolve(itemApiUrlsArray);
-  };
-
-  this.groupRecordsBy = (records, key) => {
-    const functionName = 'groupRecordsBy';
-
-    if (!records) {
-      throw HoldRequestConsumerError({
-        message: 'the records array is not defined',
-        type: 'undefined-records-array-parameter',
-        function: functionName
-      });
-    }
-
-    if (!records.length) {
-      throw HoldRequestConsumerError({
-        message: 'the records array is empty',
-        type: 'empty-records-array-parameter',
-        function: functionName
-      });
-    }
-
-    if (!key || key === '') {
-      throw HoldRequestConsumerError({
-        message: 'the key parameter is not defined or empty',
-        type: 'undefined-key-parameter',
-        function: functionName
-      });
-    }
-
-    const matchingRecordsObject = records.reduce((allRecords, record) => {
-      allRecords[record[key]] = allRecords[record[key]] || [];
-      allRecords[record[key]].push(record);
-      return allRecords;
-    }, {});
-
-    return matchingRecordsObject;
-  };
-
-  this.getOAuthToken = (cachedToken) => {
-    const functionName = 'getOAuthToken';
+  this.getTokenFromOAuthService = (cachedToken) => {
+    const functionName = 'getTokenFromOAuthService';
     const authConfig = {
       client_id: this.clientId,
       client_secret: this.clientSecret,
@@ -391,15 +216,21 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
     };
 
     if (!this.areRequiredParamsValid()) {
+      logger.error(
+        `OAuth required parameters are not defined in function: ${functionName}`,
+        { params: 'client_id, client_secret, grant_type, scope' }
+      );
       return Promise.reject(HoldRequestConsumerError({
           message: 'OAuth required parameters are not defined',
-          type: 'missing-constructor-required-params',
+          type: 'missing-constructor-oauth-required-params',
           function: functionName
         })
       );
     }
 
-    return (!cachedToken) ? axios
+    if (!cachedToken) {
+      logger.info('fetching new token from OAuth Service');
+      return axios
       .post(this.oauthUrl, qs.stringify(authConfig))
       .then((response) => {
         if (response && response.data && response.data.access_token) {
@@ -407,6 +238,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
         }
 
         // We obtained a valid response. However, we could not get a value from access_token
+        logger.error(`missing access_token value from OAuth Service response in function: ${functionName}`);
         return Promise.reject(HoldRequestConsumerError({
             message: 'missing access_token value from OAuth Service',
             type: 'missing-access-token-from-oauth-service',
@@ -418,6 +250,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
         if (error.response) {
           // The request was made and the server responded with a status code
           // that falls out of the range of 2xx
+          logger.error(`received a status outside of the 2xx range from OAuth Service in function: ${functionName}`);
           return Promise.reject(HoldRequestConsumerError({
               message: 'received a status outside of the 2xx range',
               type: 'oauth-service-error',
@@ -435,25 +268,29 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
 
         if (error.request) {
           // The request was made but no response was received
+          logger.error(`request was made, no response OAuth Service in function: ${functionName}`);
           return Promise.reject(HoldRequestConsumerError({
               message: 'request was made, no response from OAuth Service',
               type: 'oauth-service-error',
-              status: 500,
               function: functionName,
               error : error.request
             })
           );
         }
 
+        logger.error(`An internal server error occurred from OAuth Service in function: ${functionName}`);
         return Promise.reject(HoldRequestConsumerError({
-            message: error.message,
+            message: 'An internal server error occurred',
             type: 'oauth-service-error',
             status: 500,
             function: functionName
           })
         );
       })
-      : Promise.resolve(cachedToken);
+    } else {
+      logger.info('Already obtained an access_token from CACHE, not executing call to get token from OAuth Service');
+      Promise.resolve(cachedToken);
+    }
   };
 }
 

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -1,4 +1,5 @@
 /* eslint-disable semi */
+const async = require('async');
 const axios = require('axios');
 const qs = require('qs');
 const HoldRequestConsumerError = require('../models/HoldRequestConsumerError');
@@ -29,30 +30,208 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
       this.clientSecret === '' || this.scope === '') ? false : true;
   };
 
+  this.processBatchRequest = (urlsArray, token, type) => {
+    const functionName = 'processBatchRequest';
+    if (!token || token === '') {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the token parameter is not defined or empty',
+          type: 'undefined-token-parameter',
+          function: functionName
+        })
+      );
+    }
+
+    if (!urlsArray.length) {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the urls array parameter is empty',
+          type: 'empty-urls-array-parameter',
+          function: functionName
+        })
+      );
+    }
+
+    if (!type || type === '') {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the type parameter is not defined or empty',
+          type: 'undefined-type-parameter',
+          function: functionName
+        })
+      );
+    }
+
+    return new Promise(function (resolve, reject) {
+      if (type === 'itemApi') {
+        async.map(urlsArray, function(urlItem, cb) {
+          return axios.get(urlItem.itemApi,
+            { headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`
+              }
+            }
+          )
+          .then(response => {
+            if (response.data && response.data.data) {
+              cb(null, response.data.data);
+            }
+          })
+          .catch((error) => cb(error));
+        }, (err, results) => {
+          if (err) {
+            let errorResponse;
+            if (err.response) {
+              // The request was made and the server responded with a status code
+              // that falls out of the range of 2xx
+              errorResponse = HoldRequestConsumerError({
+                message: 'received a status outside of the 2xx range from Item Service',
+                type: 'item-service-api',
+                status: err.response.status,
+                function: functionName,
+                error : {
+                  method: err.response.request.method,
+                  url: err.response.request.path,
+                  headers: err.response.headers,
+                  data: err.response.data
+                }
+              });
+            } else if (err.request) {
+              // The request was made but no response was received
+              errorResponse = HoldRequestConsumerError({
+                message: 'request was made, no response from Item Service',
+                type: 'item-service-api',
+                status: 500,
+                function: functionName,
+                error : err.request
+              });
+            } else {
+              errorResponse = HoldRequestConsumerError({
+                message: err.message,
+                type: 'item-service-api',
+                status: 500,
+                function: functionName
+              });
+            }
+            reject(errorResponse);
+          } else {
+            // Merge two-dimensional array
+            const mergedArrayResults = [].concat.apply([], results);
+            resolve(mergedArrayResults);
+          }
+        });
+      }
+
+      if (type === 'patronBarcodeApi') {
+        async.map(urlsArray, function(urlItem, callback) {
+          return axios.get(urlItem.patronBarcodeApi,
+            { headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`
+              }
+            }
+          )
+          .then(response => {
+            if (response.data && response.data.data) {
+              callback(null, response.data.data);
+            }
+          })
+          .catch((error) => callback(error));
+        }, (err, results) => {
+          // if (!err) {
+          //   // Merge two-dimensional array
+            // const mergedArrayResults = [].concat.apply([], results);
+            // resolve(mergedArrayResults);
+          // }
+
+          let errorResponse;
+          // Handle the appropriate error for each result
+          if (err) {
+            if (err.response) {
+              // The request was made and the server responded with a status code
+              // that falls out of the range of 2xx
+              errorResponse = HoldRequestConsumerError({
+                message: 'received a status outside of the 2xx range from Patron Service',
+                type: 'patron-service-api',
+                status: err.response.status,
+                function: functionName,
+                error : {
+                  method: err.response.request.method,
+                  url: err.response.request.path,
+                  headers: err.response.headers,
+                  data: err.response.data
+                }
+              });
+            } else if (err.request) {
+              // The request was made but no response was received
+              errorResponse = HoldRequestConsumerError({
+                message: 'request was made, no response from Patron Service',
+                type: 'patron-service-api',
+                status: 500,
+                function: functionName,
+                error : err.request
+              });
+            } else {
+              errorResponse = HoldRequestConsumerError({
+                message: err.message,
+                type: 'patron-service-api',
+                status: 500,
+                function: functionName
+              });
+            }
+
+            reject(errorResponse);
+          } else {
+            const mergedArrayResults = [].concat.apply([], results);
+            resolve(mergedArrayResults);
+          }
+        });
+      }
+    });
+  };
+
   this.generateRecordApiUrlsArray = (records, baseApiUrl) => {
     const functionName = 'setItemApiUrlToRecord';
     if (!baseApiUrl || baseApiUrl === '') {
-      throw HoldRequestConsumerError({
-        message: 'the baseApiUrl parameter is not defined or empty',
-        type: 'undefined-item-api-url-parameter',
-        function: functionName
-      });
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the baseApiUrl parameter is not defined or empty',
+          type: 'undefined-base-api-url-parameter',
+          function: functionName
+        })
+      );
     }
 
     if (!records) {
-      throw HoldRequestConsumerError({
-        message: 'the records object parameter is not defined',
-        type: 'undefined-records-object-parameter',
-        function: functionName
-      });
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the records array parameter is not defined',
+          type: 'undefined-records-array-parameter',
+          function: functionName
+        })
+      );
     }
 
-    if (Object.keys(records).length === 0) {
-      throw HoldRequestConsumerError({
-        message: 'the records object parameter is empty, could not iterate over object keys',
-        type: 'empty-records-object-parameter',
-        function: functionName
-      });
+    if (!records.length) {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the records array parameter is empty',
+          type: 'empty-records-array-parameter',
+          function: functionName
+        })
+      );
+    }
+
+    const groupedRecords = this.groupRecordsBy(records, 'nyplSource');
+
+    if (Object.keys(groupedRecords).length === 0) {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the groupedRecords object is empty, could not iterate over object keys',
+          type: 'empty-grouped-records-object',
+          function: functionName
+        })
+      );
     }
 
     // Create the Items API URL from the base URL
@@ -63,38 +242,44 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
     let itemApiUrl = itemApiUrlBase;
     let patronBarcodeApiUrl = '';
     // Iterate over the records object keys grouped by nyplSource
-    Object.keys(records).forEach((key) => {
-      const arrayOfDecodedRecords = records[key];
+    Object.keys(groupedRecords).forEach((key) => {
+      const arrayOfDecodedRecords = groupedRecords[key];
 
       if (typeof arrayOfDecodedRecords !== 'object' || !arrayOfDecodedRecords.length) {
-        throw HoldRequestConsumerError({
-          message: 'the decoded data array is empty',
-          type: 'empty-decoded-data-array',
-          function: functionName,
-          error: { nyplSource: key, data: arrayOfDecodedRecords }
-        });
+        return Promise.reject(
+            HoldRequestConsumerError({
+            message: 'the decoded data array is empty',
+            type: 'empty-decoded-data-array',
+            function: functionName,
+            error: { nyplSource: key, data: arrayOfDecodedRecords }
+          })
+        );
       }
 
       // Iterate over each record data to extract the record id
       Object.keys(arrayOfDecodedRecords).forEach((k) => {
         // Verify the existence of the 'record' property
         if (!arrayOfDecodedRecords[k].hasOwnProperty('record') || !arrayOfDecodedRecords[k].record) {
-          throw HoldRequestConsumerError({
-            message: 'the record object key within the item id is not defined',
-            type: 'empty-object-property-record',
-            function: functionName,
-            error: { nyplSource: key, data: arrayOfDecodedRecords[k] }
-          });
+          return Promise.reject(
+            HoldRequestConsumerError({
+              message: 'the record object key within the item id is not defined',
+              type: 'empty-object-property-record',
+              function: functionName,
+              error: { nyplSource: key, data: arrayOfDecodedRecords[k] }
+            })
+          );
         }
 
         // Verify the existence of the 'record' property
         if (!arrayOfDecodedRecords[k].hasOwnProperty('patron') || !arrayOfDecodedRecords[k].patron) {
-          throw HoldRequestConsumerError({
-            message: 'the patron object key within the patron id is not defined',
-            type: 'empty-object-property-patron',
-            function: functionName,
-            error: { nyplSource: key, data: arrayOfDecodedRecords[k] }
-          });
+          return Promise.reject(
+              HoldRequestConsumerError({
+              message: 'the patron object key within the patron id is not defined',
+              type: 'empty-object-property-patron',
+              function: functionName,
+              error: { nyplSource: key, data: arrayOfDecodedRecords[k] }
+            })
+          );
         }
         // Generate patron barcode url
         patronBarcodeApiUrl = `${patronBarcodeApiUrlBase}/${arrayOfDecodedRecords[k].patron}/barcode`;
@@ -112,15 +297,15 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
       // Add the Item API Url and data to final array
       itemApiUrlsArray.push({
         'nyplSource': key,
-        'itemApiUrl': itemApiUrl,
-        'patronBarcodeApiUrl': patronBarcodeApiUrl,
+        'itemApi': itemApiUrl,
+        'patronBarcodeApi': patronBarcodeApiUrl,
         'data': arrayOfDecodedRecords
       });
       // Reset the item URL for the next record
       itemApiUrl = itemApiUrlBase;
     });
 
-    return itemApiUrlsArray;
+    return Promise.resolve(itemApiUrlsArray);
   };
 
   this.getItemData = (records, apiUrl) => {
@@ -205,7 +390,12 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
               type: 'oauth-service-error',
               status: error.response.status,
               function: functionName,
-              error : { headers: error.response.headers, data: error.response.data }
+              error : {
+                method: error.response.request.method,
+                url: error.response.request.path,
+                headers: error.response.headers,
+                data: error.response.data
+              }
             })
           );
         }

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -78,7 +78,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
             // TODO: POST FAILURE TO STREAM
             logger.error(
               'unable to retrieve item data for hold request record, posting failed record to HoldRequestResult stream',
-              { holdRequestId: item.id, record: item }
+              { holdRequestId: item.id, record: item, error: error.response }
             );
 
             // Ignore all other failures and continue with callback, except 401 (access_token expired)
@@ -138,7 +138,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
             // TODO: POST FAILURE TO STREAM
             logger.error(
               'unable to retrieve patron data for hold request record, posting failed record to HoldRequestResult stream',
-              { holdRequestId: item.id, record: item }
+              { holdRequestId: item.id, record: item, error: error.response }
             );
 
             // Ignore all other failures and continue with callback, except 401 (access_token expired)

--- a/src/helpers/Logger.js
+++ b/src/helpers/Logger.js
@@ -38,9 +38,9 @@ const logger = new winston.Logger({
         }
 
         if (options.meta && Object.keys(options.meta).length) {
-          if (options.meta.jobId) {
-            result.jobId = options.meta.jobId;
-            delete options.meta.jobId;
+          if (options.meta.holdRequestId) {
+            result.holdRequestId = options.meta.holdRequestId;
+            delete options.meta.holdRequestId;
           }
 
           if (options.meta && Object.keys(options.meta).length) {

--- a/src/helpers/Logger.js
+++ b/src/helpers/Logger.js
@@ -33,10 +33,6 @@ const logger = new winston.Logger({
           result.message = options.message;
         }
 
-        if (process.pid) {
-          result.pid = process.pid.toString();
-        }
-
         if (options.meta && Object.keys(options.meta).length) {
           if (options.meta.holdRequestId) {
             result.holdRequestId = options.meta.holdRequestId;
@@ -46,6 +42,10 @@ const logger = new winston.Logger({
           if (options.meta && Object.keys(options.meta).length) {
             result.meta = JSON.stringify(options.meta);
           }
+        }
+
+        if (process.pid) {
+          result.pid = process.pid.toString();
         }
 
         return JSON.stringify(result);

--- a/src/models/HoldRequestConsumerError.js
+++ b/src/models/HoldRequestConsumerError.js
@@ -15,6 +15,10 @@ function HoldRequestConsumerError (settings, implementationContext) {
     this.status = settings.status;
   }
 
+  if (settings.holdRequestId) {
+    this.holdRequestId = settings.holdRequestId;
+  }
+
   if (settings.function) {
     this.function = settings.function;
   }

--- a/src/models/HoldRequestConsumerModel.js
+++ b/src/models/HoldRequestConsumerModel.js
@@ -7,7 +7,7 @@ function HoldRequestConsumerModel(records) {
   }
 
   this.records = null;
-  this.apiUrlsArray = null;
+  this.itemApiUrls = null;
 
   this.initialize = (records) => {
     if (typeof records === 'object' && records.length) {
@@ -29,12 +29,12 @@ function HoldRequestConsumerModel(records) {
     this.records = records;
   };
 
-  this.getApiUrlsArray = () => {
-    return this.apiUrlsArray;
+  this.getItemServiceApiUrls = () => {
+    return this.itemApiUrls;
   };
 
-  this.setApiUrlsArray = (urlsArray) => {
-    this.apiUrlsArray = urlsArray;
+  this.setItemServiceApiUrls = (urlsArray) => {
+    this.itemApiUrls = urlsArray;
   };
 
   this.mergeRecordsBySourceAndRecordId = (initialRecords, updatedRecords) => {

--- a/src/models/HoldRequestConsumerModel.js
+++ b/src/models/HoldRequestConsumerModel.js
@@ -1,25 +1,12 @@
 /* eslint-disable semi */
-const _ = require('lodash');
 const HoldRequestConsumerError = require('./HoldRequestConsumerError');
-function HoldRequestConsumerModel(records) {
+
+function HoldRequestConsumerModel() {
   if (!(this instanceof HoldRequestConsumerModel)) {
-    return new HoldRequestConsumerModel(records);
+    return new HoldRequestConsumerModel();
   }
 
   this.records = null;
-  this.itemApiUrls = null;
-
-  this.initialize = (records) => {
-    if (typeof records === 'object' && records.length) {
-      return this.setRecords(records);
-    }
-
-    throw HoldRequestConsumerError({
-      message: 'the records array is not defined',
-      type: 'undefined-records-array-parameter',
-      function: 'HoldRequestConsumerModel.initialize'
-    });
-  };
 
   this.getRecords = () => {
     return this.records;
@@ -27,50 +14,6 @@ function HoldRequestConsumerModel(records) {
 
   this.setRecords = (records) => {
     this.records = records;
-  };
-
-  this.getItemServiceApiUrls = () => {
-    return this.itemApiUrls;
-  };
-
-  this.setItemServiceApiUrls = (urlsArray) => {
-    this.itemApiUrls = urlsArray;
-  };
-
-  this.mergeRecordsBySourceAndRecordId = (initialRecords, updatedRecords) => {
-    const functionName = 'mergeRecordsBySourceAndRecordId';
-
-    if (!initialRecords.length) {
-      return Promise.reject(
-        HoldRequestConsumerError({
-          message: 'the initialRecords array parameter is empty',
-          type: 'empty-initial-records-array-parameter',
-          function: functionName
-        })
-      );
-    }
-
-    if (!updatedRecords.length) {
-      return Promise.reject(
-        HoldRequestConsumerError({
-          message: 'the updatedRecords array parameter is empty',
-          type: 'empty-updated-records-array-parameter',
-          function: functionName
-        })
-      );
-    }
-
-    const mergedRecords = _.map(initialRecords, function(item) {
-      const matchedRecord = _.find(updatedRecords, { id: item.record, nyplSource: item.nyplSource });
-      return _.extend(item, { 'item': matchedRecord });
-    });
-
-    return mergedRecords && mergedRecords.length ? Promise.resolve(mergedRecords)
-      : Promise.reject(HoldRequestConsumerError({
-        message: 'the mergedRecords array is could not be generated while attempting to merge by nyplSource and record id',
-        type: 'undefined-merged-records-array',
-        function: functionName
-      }));
   };
 }
 

--- a/src/models/HoldRequestConsumerModel.js
+++ b/src/models/HoldRequestConsumerModel.js
@@ -1,4 +1,5 @@
 /* eslint-disable semi */
+const _ = require('lodash');
 const HoldRequestConsumerError = require('./HoldRequestConsumerError');
 function HoldRequestConsumerModel(records) {
   if (!(this instanceof HoldRequestConsumerModel)) {
@@ -6,6 +7,7 @@ function HoldRequestConsumerModel(records) {
   }
 
   this.records = null;
+  this.apiUrlsArray = null;
 
   this.initialize = (records) => {
     if (typeof records === 'object' && records.length) {
@@ -25,6 +27,50 @@ function HoldRequestConsumerModel(records) {
 
   this.setRecords = (records) => {
     this.records = records;
+  };
+
+  this.getApiUrlsArray = () => {
+    return this.apiUrlsArray;
+  };
+
+  this.setApiUrlsArray = (urlsArray) => {
+    this.apiUrlsArray = urlsArray;
+  };
+
+  this.mergeRecordsBySourceAndRecordId = (initialRecords, updatedRecords) => {
+    const functionName = 'mergeRecordsBySourceAndRecordId';
+
+    if (!initialRecords.length) {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the initialRecords array parameter is empty',
+          type: 'empty-initial-records-array-parameter',
+          function: functionName
+        })
+      );
+    }
+
+    if (!updatedRecords.length) {
+      return Promise.reject(
+        HoldRequestConsumerError({
+          message: 'the updatedRecords array parameter is empty',
+          type: 'empty-updated-records-array-parameter',
+          function: functionName
+        })
+      );
+    }
+
+    const mergedRecords = _.map(initialRecords, function(item) {
+      const matchedRecord = _.find(updatedRecords, { id: item.record, 'nyplSource': item.nyplSource });
+      return _.extend(item, { 'item': matchedRecord });
+    });
+
+    return mergedRecords && mergedRecords.length ? Promise.resolve(mergedRecords)
+      : Promise.reject(HoldRequestConsumerError({
+        message: 'the mergedRecords array is could not be generated while attempting to merge by nyplSource and record id',
+        type: 'undefined-merged-records-array',
+        function: functionName
+      }));
   };
 }
 

--- a/src/models/HoldRequestConsumerModel.js
+++ b/src/models/HoldRequestConsumerModel.js
@@ -61,7 +61,7 @@ function HoldRequestConsumerModel(records) {
     }
 
     const mergedRecords = _.map(initialRecords, function(item) {
-      const matchedRecord = _.find(updatedRecords, { id: item.record, 'nyplSource': item.nyplSource });
+      const matchedRecord = _.find(updatedRecords, { id: item.record, nyplSource: item.nyplSource });
       return _.extend(item, { 'item': matchedRecord });
     });
 


### PR DESCRIPTION
This PR adds the ability to process the GET requests for each record to obtain **item** and **patron** data from NYPL Data API's. Logging is added and comments mark places where posting failures to stream will occur. I am only throwing errors and rejecting the Promise chain on status code 401 which will imply that the access_token is invalid and therefore will need to re-fetch a new one.

P.S. I updated the way CACHE was initialized so it can be shareable across modules.