### PR TITLE
fixes #16 add filter to remove all requests with 'processed = true'

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,12 @@ exports.kinesisHandler = (records, opts = {}, context, callback) => {
         logger.info('reusing access_token already defined in CACHE, no API call to OAuth Service was executed');
       }
 
-      logger.info('storing decoded kinesis records to HoldRequestConsumerModel');
-      hrcModel.setRecords(result[1]);
+      // Filter out records a processed flag of true before storing to prevent re-processing.
+      var filteredRecords = apiHelper.filterProcessedRecords(result[1]);
+      logger.info(`total records decoded: ${result[1].length}; total records to process: ${filteredRecords.length}`);
+
+      logger.info('storing decoded/filtered kinesis records to HoldRequestConsumerModel');
+      hrcModel.setRecords(filteredRecords);
 
       return apiHelper.handleHttpAsyncRequests(
         hrcModel.getRecords(),

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -234,13 +234,6 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
   this.handleHttpAsyncRequests = (records, type, apiUrl, accessToken) => {
     const functionName = 'handleHttpAsyncRequests';
 
-    // Filter out records from stream with a processed flag of true since these were posted to the stream via
-    // the PATCH /api/v0.1/hold-requests endpoint which have already been sent to SCSB.
-    logger.info(`filter records array to only unprocessed requests. will be empty if all requests have been processed.`);
-    records = records.filter(function (record) {
-      return record.processed === false;
-    });
-
     if (!records.length) {
       return Promise.reject(
         HoldRequestConsumerError({
@@ -363,6 +356,28 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
 
     return Promise.resolve('access-token-exists-in-cache');
   };
+
+  this.filterProcessedRecords = (records) => {
+    const functionName = 'filterProcessedRecords';
+
+    if (!records.length) {
+      return Promise.reject(
+          HoldRequestConsumerError({
+            message: 'no records to filter. An empty array was passed.',
+            type: 'empty-function-parameter',
+            function: functionName
+          })
+      );
+    }
+
+    if (records.length > 0) {
+      logger.info(`filtering out records with a processed flag equal to true. may result in an empty array.`);
+      return unprocessedRecords = records.filter(function (record) {
+        return record.processed === false;
+      });
+    }
+
+  }
 }
 
 module.exports = ApiServiceHelper;

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -234,6 +234,13 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
   this.handleHttpAsyncRequests = (records, type, apiUrl, accessToken) => {
     const functionName = 'handleHttpAsyncRequests';
 
+    // Filter out records from stream with a processed flag of true since these were posted to the stream via
+    // the PATCH /api/v0.1/hold-requests endpoint which have already been sent to SCSB.
+    logger.info(`filter records array to only unprocessed requests. will be empty if all requests have been processed.`);
+    records = records.filter(function (record) {
+      return record.processed === false;
+    });
+
     if (!records.length) {
       return Promise.reject(
         HoldRequestConsumerError({


### PR DESCRIPTION
Added an array filter to remove requests already processed to prevent re-posting to NYPL and ReCAP APIs. This attempt should allow all unprocessed requests through. If a better test is needed, let me know.