### PR TITLE
Added function getLogLevelCode to produce appropriate log level code

### DIFF
--- a/src/helpers/Logger.js
+++ b/src/helpers/Logger.js
@@ -16,6 +16,29 @@ const nyplLogLevels = {
   }
 };
 
+const getLogLevelCode = (levelString) => {
+  switch (levelString) {
+    case 'emergency':
+      return 0;
+    case 'alert':
+      return 1;
+    case 'critical':
+      return 2;
+    case 'error':
+      return 3;
+    case 'warning':
+      return 4;
+    case 'notice':
+      return 5;
+    case 'info':
+      return 6;
+    case 'debug':
+      return 7;
+    default:
+      return 'n/a';
+  }
+};
+
 const logger = new winston.Logger({
   levels: nyplLogLevels.levels,
   transports: [
@@ -26,6 +49,7 @@ const logger = new winston.Logger({
       formatter: (options) => {
         const result = {
           timestamp: options.timestamp(),
+          levelCode: getLogLevelCode(options.level),
           level: options.level.toUpperCase()
         };
 


### PR DESCRIPTION
quick PR that adds the levelCode functionality in the Logger via Winston. With this new feature, we can add alarm logic to check levelCode as integer to send alarms/emails etc...

This is in accordance to our Engineering guidelines under Logging -- https://github.com/NYPL/engineering-general/blob/master/standards/logging.md#logging

Next step is to break this into an npm nypl winston module.