### PR TITLE
Added decryption library and setup kinesis handler to use production ENV flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,14 @@ An example of the sample deployment environment `.env` file:
 ```console
 NYPL_DATA_API_URL=XXX
 OAUTH_PROVIDER_URL=XXX
-OAUTH_PROVIDER_SCOPE=XXX
-OAUTH_CLIENT_ID=XXX
-OAUTH_CLIENT_SECRET=XXX
+OAUTH_PROVIDER_SCOPE=XXX // Encrypted in AWS
+OAUTH_CLIENT_ID=XXX // Encrypted in AWS
+OAUTH_CLIENT_SECRET=XXX // Encrypted in AWS
 HOLD_REQUEST_SCHEMA_NAME=XXX
 HOLD_REQUEST_RESULT_STREAM_NAME=XXX
 SCSB_API_BASE_URL=XXX
-SCSB_API_KEY=XXX
+SCSB_API_KEY=XXX // Encrypted in AWS
+NODE_ENV=XXX // Use `development` when developing locally via `npm run local-run`. If deploying to AWS via `npm run deploy-ENV` use `production`, this will trigger the decryption client for encrypted ENV variables.
 ```
 
 #### Step 4: Setup your environment specific `event_sources_{environment}.json` file
@@ -193,8 +194,10 @@ $ npm run lint [filename].js // Will lint the specific JS file
 ## NPM Dependencies
 * [nypl-streams-client](https://www.npmjs.com/package/@nypl/nypl-streams-client)
 * [nypl-scsb-rest-client](https://www.npmjs.com/package/@nypl/scsb-rest-client)
+* [aws-sdk](https://www.npmjs.com/package/aws-sdk)
 * [async](https://www.npmjs.com/package/async)
 * [axios](https://www.npmjs.com/package/axios)
+* [lambda-env-vars](https://www.npmjs.com/package/lambda-env-vars)
 * [qs](https://www.npmjs.com/package/qs)
 * [winston](https://www.npmjs.com/package/winston)
 * [node-lambda](https://www.npmjs.com/package/node-lambda)

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
   },
   "homepage": "https://github.com/NYPL/nypl-hold-request-consumer#readme",
   "dependencies": {
-    "@nypl/nypl-streams-client": "0.1.4",
     "@nypl/nypl-core-objects": "1.1.2",
+    "@nypl/nypl-streams-client": "0.1.4",
     "@nypl/scsb-rest-client": "1.0.2",
     "async": "2.5.0",
+    "aws-sdk": "2.97.0",
     "axios": "0.16.2",
+    "lambda-env-vars": "0.4.0",
     "qs": "6.4.0",
     "winston": "2.3.1"
   },

--- a/sample/deployment.env.sample
+++ b/sample/deployment.env.sample
@@ -7,3 +7,4 @@ HOLD_REQUEST_SCHEMA_NAME=XXX
 HOLD_REQUEST_RESULT_STREAM_NAME=XXX
 SCSB_API_BASE_URL=XXX
 SCSB_API_KEY=XXX
+NODE_ENV=XXX // Use 'development' when developing locally via `npm run local-run`. If deploying to AWS use 'production', this will trigger the decryption client.


### PR DESCRIPTION
This PR adds the aws-sdk and lambda-env-vars package that enables the Lambda to decrypt ENV variables ONLY when the NODE_ENV is 'production'. Otherwise, it will run in local development mode without decryption.

To test in production:

Log into AWS console, run test event and check log output. If you check the ENV variables in AWS console, the OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, SCSB_API_KEY are all encrypted.

To test locally:

Use the following ENV variables in your ./config/local.env

```
NYPL_DATA_API_URL=https://api.nypltech.org/api/v0.1/
OAUTH_PROVIDER_URL=https://isso.nypl.org/oauth/token
OAUTH_PROVIDER_SCOPE=XXX
OAUTH_CLIENT_ID=XXX
OAUTH_CLIENT_SECRET=XXX
HOLD_REQUEST_SCHEMA_NAME=HoldRequest
HOLD_REQUEST_RESULT_STREAM_NAME=HoldRequestResult
SCSB_API_BASE_URL=https://uat-recap.htcinc.com:9093
SCSB_API_KEY=XXX
NODE_ENV=development
```

Then run ```npm run local-run``` -- It will use the ENV variables from local.env which are NOT encrypted.