### PR TITLE
Updated codebase to use patrons/{id} endpoint instead of patrons/{id}/barcode to adjust to upcoming Patron Service iteration

### DIFF
--- a/src/helpers/SCSBApiHelper.js
+++ b/src/helpers/SCSBApiHelper.js
@@ -268,7 +268,8 @@ const SCSBApiHelper = module.exports = {
 
     // Extract Patron Barcode
     if (object.patronInfo && Array.isArray(object.patronInfo.barCodes) && object.patronInfo.barCodes.length) {
-      scsbModel.patronBarcode = object.patronInfo.barCodes[0]; // obtain first barcode item in array
+      const barCodesArray = object.patronInfo.barCodes;
+      scsbModel.patronBarcode = barCodesArray[barCodesArray.length - 1]; // obtain last barcode item in array
     }
 
     if (object.item) {

--- a/src/helpers/SCSBApiHelper.js
+++ b/src/helpers/SCSBApiHelper.js
@@ -267,8 +267,8 @@ const SCSBApiHelper = module.exports = {
     }
 
     // Extract Patron Barcode
-    if (object.patronInfo && object.patronInfo.barCode) {
-      scsbModel.patronBarcode = object.patronInfo.barCode;
+    if (object.patronInfo && Array.isArray(object.patronInfo.barCodes) && object.patronInfo.barCodes.length) {
+      scsbModel.patronBarcode = object.patronInfo.barCodes[0]; // obtain first barcode item in array
     }
 
     if (object.item) {

--- a/test/helpers/SCSBApiHelper.test.js
+++ b/test/helpers/SCSBApiHelper.test.js
@@ -258,5 +258,17 @@ describe('HoldRequestConsumer Lambda: SCSB API Helper', () => {
 
       return expect(result).to.eql({ requestingInstitution: 'NYPL', requestType: 'RETRIEVAL', itemOwningInstitution: 'NYPL' });
     });
+
+    it('should return an object without a patronBarcode property if the barCodes array supplied is empty', () => {
+      const result = generateSCSBModel({ requestType: 'hold', nyplSource: 'sierra-nypl', patronInfo: { barCodes: [] } });
+
+      return expect(result).to.eql({ requestingInstitution: 'NYPL', requestType: 'RETRIEVAL', itemOwningInstitution: 'NYPL' });
+    });
+
+    it('should return an object with properties (requestingInstitution, requestType and itemOwningInstitution and patronBarcode) if requestType is hold and nyplSource is sierra-nypl and the barCodes array is defined', () => {
+      const result = generateSCSBModel({ requestType: 'hold', nyplSource: 'sierra-nypl', patronInfo: { barCodes: ['1234'] } });
+
+      return expect(result).to.eql({ requestingInstitution: 'NYPL', requestType: 'RETRIEVAL', itemOwningInstitution: 'NYPL', patronBarcode: '1234' });
+    });
   });
 });


### PR DESCRIPTION
- Added checks to the response to ensure a barcode array was defined
- Added logic to POST failure to result stream of no array of barcodes is returned by the Patron Service
- Added unit test to check existence of SCSB Model object property.

