### PR TITLE
update nypl-core-objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/NYPL/nypl-hold-request-consumer#readme",
   "dependencies": {
-    "@nypl/nypl-core-objects": "1.1.7",
+    "@nypl/nypl-core-objects": "1.3.0",
     "@nypl/nypl-streams-client": "0.1.4",
     "@nypl/scsb-rest-client": "1.0.4",
     "async": "2.5.0",

--- a/sample/deployment.env.sample
+++ b/sample/deployment.env.sample
@@ -8,4 +8,5 @@ HOLD_REQUEST_RESULT_STREAM_NAME=XXX
 HOLD_REQUEST_RESULT_SCHEMA_NAME=XXX
 SCSB_API_BASE_URL=XXX
 SCSB_API_KEY=XXX
+NYPL_CORE_VERSION=XXX // Use to specify ReCAP Customer Code mappings for testing/pre-release.
 NODE_ENV=XXX // Use 'development' when developing locally via `npm run local-run`. If deploying to AWS use 'production', this will trigger the decryption client.


### PR DESCRIPTION
Update nypl-core-objects npm to v1.3.0 for new NYPL_CORE_VERSION change

Add NYPL_CORE_VERSION var to sample/deployment.env.sample

This change allows us to test different versions of the mappings in the nypl-core repository for pre-release and stable release tags.