### PR TITLE
Fix bug requesting HL items from SCSB

### DIFF
--- a/src/helpers/SCSBApiHelper.js
+++ b/src/helpers/SCSBApiHelper.js
@@ -229,16 +229,14 @@ const SCSBApiHelper = module.exports = {
   },
   getInstitutionCode: (nyplCode) => {
     // Codes defined in https://htcrecap.atlassian.net/wiki/display/RTG/Request+Item
-    if (nyplCode === 'recap-cul') {
-      return 'CUL';
+
+    // Check for partner institution code (e.g. recap-hl, recap-cul, recap-pul)
+    if (/^recap-/.test(nyplCode)) {
+      return nyplCode.split('-')[1].toUpperCase();
     }
 
     if (nyplCode === 'sierra-nypl') {
       return 'NYPL';
-    }
-
-    if (nyplCode === 'recap-pul') {
-      return 'PUL';
     }
   },
   generateSCSBModel: (object = {}) => {

--- a/test/helpers/SCSBApiHelper.test.js
+++ b/test/helpers/SCSBApiHelper.test.js
@@ -192,6 +192,12 @@ describe('HoldRequestConsumer Lambda: SCSB API Helper', () => {
 
       return expect(result).to.eql('NYPL');
     });
+
+    it('should return a matching institution code if recap-hl passed', () => {
+      const result = getInstitutionCode('recap-hl');
+
+      return expect(result).to.eql('HL');
+    });
   });
 
   describe('generateSCSBModel(object) function', () => {


### PR DESCRIPTION
Fixes the translation between nyplSource and the institution code that
SCSB needs in /requestItem/requestItem. Previously this component only
handled CUL and PUL. This update generally supports translating recap-*
into the obvious 2-3 char institution code that SCSB expects.