### PR TITLE
Scc 4972

### DIFF
--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -61,7 +61,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
           }
         );
       } else {
-        logger.error(
+        logger.warn(
           errorMessage,
           { holdRequestId: record.id,
             record: record,

--- a/src/helpers/ApiServiceHelper.js
+++ b/src/helpers/ApiServiceHelper.js
@@ -61,7 +61,7 @@ function ApiServiceHelper (url = '', clientId = '', clientSecret = '', scope = '
           }
         );
       } else {
-        logger.warn(
+        logger.warning(
           errorMessage,
           { holdRequestId: record.id,
             record: record,

--- a/src/helpers/OnSiteHoldRequestHelper.js
+++ b/src/helpers/OnSiteHoldRequestHelper.js
@@ -91,7 +91,7 @@ const OnSiteHoldRequestHelper = module.exports = {
         .catch(error => {
           const { response } = error;
           const { statusText, statusCode } = response;
-          logger.error(
+          logger.warn(
             `unable to post on-site ${eddLogText}hold request (${request.id}) to OnSiteHoldRequestService; will post to HoldRequestResult stream`,
             { holdRequestId: request.id, holdRequest: request.body, error: { statusText, statusCode } }
           )

--- a/src/helpers/OnSiteHoldRequestHelper.js
+++ b/src/helpers/OnSiteHoldRequestHelper.js
@@ -91,7 +91,7 @@ const OnSiteHoldRequestHelper = module.exports = {
         .catch(error => {
           const { response } = error;
           const { statusText, statusCode } = response;
-          logger.warn(
+          logger.warning(
             `unable to post on-site ${eddLogText}hold request (${request.id}) to OnSiteHoldRequestService; will post to HoldRequestResult stream`,
             { holdRequestId: request.id, holdRequest: request.body, error: { statusText, statusCode } }
           )

--- a/src/helpers/SCSBApiHelper.js
+++ b/src/helpers/SCSBApiHelper.js
@@ -112,7 +112,7 @@ const SCSBApiHelper = module.exports = {
               return callback(null, item);
             }
           } else {
-            logger.error(
+            logger.warn(
               `posting failed hold request record (${item.id}) to HoldRequestResult stream; the success flag is FALSE for hold request record; check debugInfo for SCSB error message`,
               { holdRequestId: item.id, debugInfo: SCSBApiHelper.getSCSBDebugInfo(result) }
             );
@@ -151,7 +151,7 @@ const SCSBApiHelper = module.exports = {
         })
         .catch(errorResponse => {
           // SCSB API ERROR
-          logger.error(
+          logger.warn(
             `unable to post hold request record (${item.id}) to SCSB API, received an error from SCSB API; posting record to HoldRequestResult stream`,
             { holdRequestId: item.id, record: item, error: errorResponse }
           );

--- a/src/helpers/SCSBApiHelper.js
+++ b/src/helpers/SCSBApiHelper.js
@@ -112,7 +112,7 @@ const SCSBApiHelper = module.exports = {
               return callback(null, item);
             }
           } else {
-            logger.warn(
+            logger.warning(
               `posting failed hold request record (${item.id}) to HoldRequestResult stream; the success flag is FALSE for hold request record; check debugInfo for SCSB error message`,
               { holdRequestId: item.id, debugInfo: SCSBApiHelper.getSCSBDebugInfo(result) }
             );
@@ -151,7 +151,7 @@ const SCSBApiHelper = module.exports = {
         })
         .catch(errorResponse => {
           // SCSB API ERROR
-          logger.warn(
+          logger.warning(
             `unable to post hold request record (${item.id}) to SCSB API, received an error from SCSB API; posting record to HoldRequestResult stream`,
             { holdRequestId: item.id, record: item, error: errorResponse }
           );


### PR DESCRIPTION
Hold Request Consumer logs are pretty noisy. This PR downgrades `error` to `warning` in several places where it seems we are logging `error` in cases that don't actually raise errors. 