### PR TITLE
Support skipping targeted request id to unblock processing

### DIFF
--- a/src/models/HoldRequestConsumerModel.js
+++ b/src/models/HoldRequestConsumerModel.js
@@ -26,6 +26,8 @@ function HoldRequestConsumerModel () {
       const filteredRecords = records.filter(record => {
         if (record.processed) {
           logger.info(`filtered out hold request record (${record.id}); contains the proccessed flag set as true and has been removed from the records array for further processing`);
+        } else if (record.id === process.env.SKIP_REQUEST_ID) {
+          logger.info(`filtered out hold request record (${record.id}); configured to skip via env variable SKIP_REQUEST_ID. Remove env variable and reset iterator to process`);
         }
 
         return !record.processed;

--- a/src/models/HoldRequestConsumerModel.js
+++ b/src/models/HoldRequestConsumerModel.js
@@ -26,8 +26,9 @@ function HoldRequestConsumerModel () {
       const filteredRecords = records.filter(record => {
         if (record.processed) {
           logger.info(`filtered out hold request record (${record.id}); contains the proccessed flag set as true and has been removed from the records array for further processing`);
-        } else if (record.id === process.env.SKIP_REQUEST_ID) {
+        } else if (String(record.id) === process.env.SKIP_REQUEST_ID) {
           logger.info(`filtered out hold request record (${record.id}); configured to skip via env variable SKIP_REQUEST_ID. Remove env variable and reset iterator to process`);
+          return false;
         }
 
         return !record.processed;

--- a/test/models/HoldRequestConsumerModel.test.js
+++ b/test/models/HoldRequestConsumerModel.test.js
@@ -184,6 +184,54 @@ describe('HoldRequestConsumer Lambda: HoldRequestConsumeModel Factory', () => {
 
       return result.should.be.fulfilled.and.eventually.be.an('array').that.includes(dummyRecords[1]);
     });
+
+    it('should remove array elements configured to skip via env var', () => {
+      const dummyRecords = [
+        {
+          id: 216,
+          jobId: '86a40625-53b7-43e3-9c95-e0a0f290f614',
+          patron: '6779366',
+          nyplSource: 'sierra-nypl',
+          createdDate: '2017-07-12T11:47:11-04:00',
+          updatedDate: null,
+          success: false,
+          processed: false,
+          requestType: 'hold',
+          recordType: 'i',
+          record: '13153327',
+          pickupLocation: 'mal',
+          neededBy: '2018-01-07T02:32:51+00:00',
+          numberOfCopies: 1,
+          deliveryLocation: null,
+          docDeliveryData: null
+        },
+        {
+          id: 217,
+          jobId: 'c1cb5981-bcd8-4d3a-873c-ae580f683cd1',
+          patron: '6779366',
+          nyplSource: 'sierra-nypl',
+          createdDate: '2017-07-12T11:48:01-04:00',
+          updatedDate: null,
+          success: false,
+          processed: false,
+          requestType: 'hold',
+          recordType: 'i',
+          record: '11064288',
+          pickupLocation: 'mal',
+          neededBy: '2018-01-07T02:32:51+00:00',
+          numberOfCopies: 1,
+          deliveryLocation: null,
+          docDeliveryData: null
+        }
+      ];
+
+      process.env.SKIP_REQUEST_ID = '217';
+      const result = hrcModel.filterProcessedRecords(dummyRecords);
+      delete process.env.API_KEY;
+
+      return result.should.be.fulfilled.and.eventually.be.an('array').that.includes(dummyRecords[0]);
+      return !result.should.be.fulfilled.and.eventually.be.an('array').that.includes(dummyRecords[1]);
+    });
   });
 
   describe('filterScsbUiRecords(array) function', () => {


### PR DESCRIPTION
* This is less destructive than moving the iterator around and ensures we will ONLY skip one problematic record at a time, very intentionally and we will note it in our logs. Record can also be processed at a later date.